### PR TITLE
Add Error-Handling to account for Proxy-API breaking and to add clearer messaging

### DIFF
--- a/src/time-badge.ts
+++ b/src/time-badge.ts
@@ -65,6 +65,9 @@ function addTimeBadges() {
                     } else {
                         showNotFoundOnBadge(badgeDiv, originalGameTitle);
                     }
+                }).catch(failed => {
+                    console.error(`fetchGameData failed: Error: \n${failed}`);
+                    errorOnBadge(badgeDiv)
                 });
         });
     });
@@ -169,6 +172,12 @@ function showNotFoundOnBadge(badgeDiv: HTMLDivElement, originalGameTitle: string
     });
 }
 
+function errorOnBadge(badgeDiv: HTMLDivElement) {
+    badgeDiv.innerText = '⦸';
+    badgeDiv.title = 'Unable to Fetch Data from HowLongToBeat-Proxy-API' +
+        '\nThis usually indicates that the HowLongToBeat-Proxy-API is not working right now. This is outside the extensions control' +
+        "\nPlease Try again at a (much) later time.";
+}
 
 genericBrowser2.storage.onChanged.addListener(function (changes) {
     if ("enableExtension" in changes) {


### PR DESCRIPTION
**Background**
Since this Extension relies heavily on an ever-breaking Proxy-API, I think it is smart to add Error-Handling and clearly state what broke for the user so you don't have x1000 Issues opened all saying "it's broken" even though your hands are tied.

**Addendum**
Anyway, once DareFox/HowLongToBeat-Proxy-API#31 gets merged this should be a non-issue (for now) 